### PR TITLE
Scope chat read receipts to workspace

### DIFF
--- a/client/src/components/ChatInput.tsx
+++ b/client/src/components/ChatInput.tsx
@@ -7,15 +7,15 @@ import { FileUploadButton } from "./FileUploadButton";
 import { KNOWLEDGE_ROUTE_BASE, KNOWLEDGE_COMMANDS, SLASH_COMMANDS, type KnowledgeCommand } from "@/constants/commands";
 
 interface ChatInputProps {
-  onSendMessage: (message: string, file?: File) => void;
+  onSendMessage: (message: string, file?: File | null) => Promise<void> | void;
   placeholder?: string;
   disabled?: boolean;
   showShortcut?: boolean;
   onShareKnowledge?: (knowledgeId: string, title: string, summary: string) => void;
 }
 
-export function ChatInput({ 
-  onSendMessage, 
+export function ChatInput({
+  onSendMessage,
   placeholder = "Type a message...", 
   disabled = false, 
   showShortcut = true,
@@ -39,9 +39,9 @@ export function ChatInput({
     }
   };
 
-  const handleKnowledgeSelect = (knowledge: KnowledgeSearchArticle) => {
+  const handleKnowledgeSelect = async (knowledge: KnowledgeSearchArticle) => {
     const knowledgeMessage = `📚 **${knowledge.title}**\n\n${knowledge.summary}\n\n[View full article](${KNOWLEDGE_ROUTE_BASE}/${knowledge.id})`;
-    onSendMessage(knowledgeMessage);
+    await onSendMessage(knowledgeMessage, null);
     onShareKnowledge?.(knowledge.id, knowledge.title, knowledge.summary);
   };
 
@@ -51,7 +51,7 @@ export function ChatInput({
     textareaRef.current?.focus();
   };
 
-  const handleSend = () => {
+  const handleSend = async () => {
     const trimmedMessage = message.trim();
     if ((trimmedMessage || selectedFile) && !disabled) {
       // Handle special commands
@@ -62,7 +62,7 @@ export function ChatInput({
       }
 
       console.log(`Sending message: ${trimmedMessage}`);
-      onSendMessage(trimmedMessage, selectedFile || undefined);
+      await onSendMessage(trimmedMessage, selectedFile);
       setMessage("");
       setSelectedFile(null);
     }
@@ -71,7 +71,7 @@ export function ChatInput({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && e.ctrlKey) {
       e.preventDefault();
-      handleSend();
+      void handleSend();
     }
     
     if (e.key === "Escape" && showCommands) {
@@ -200,8 +200,8 @@ export function ChatInput({
 
               <Button
                 size="icon"
-                onClick={handleSend}
-                disabled={!message.trim() || disabled}
+                onClick={() => void handleSend()}
+                disabled={disabled || (!message.trim() && !selectedFile)}
                 data-testid="button-send-message"
                 className="h-7 w-7 bg-green-600 hover:bg-blue-600 dark:bg-green-700 dark:hover:bg-blue-700 transition-colors duration-200"
               >

--- a/client/src/components/ChatThread.tsx
+++ b/client/src/components/ChatThread.tsx
@@ -28,7 +28,7 @@ interface ChatThreadProps {
   };
   threadMessages: ThreadMessage[];
   onClose: () => void;
-  onSendReply: (content: string) => void;
+  onSendReply: (content: string, file?: File | null) => Promise<void> | void;
   isLoading?: boolean;
   className?: string;
 }

--- a/client/src/components/MessageReactions.tsx
+++ b/client/src/components/MessageReactions.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/ui/popover';
 import { Smile, ThumbsUp, Heart, Laugh, Frown, Angry } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useTranslation } from '@/contexts/LanguageContext';
 
 interface Reaction {
   emoji: string;
@@ -43,6 +44,7 @@ export function MessageReactions({
   onRemoveReaction,
   disabled = false,
 }: MessageReactionsProps) {
+  const { t } = useTranslation();
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   const handleReactionClick = (emoji: string, hasReacted: boolean) => {
@@ -93,39 +95,41 @@ export function MessageReactions({
       ))}
 
       {/* Add reaction button */}
-      <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={disabled}
-            className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
-          >
-            <Smile className="h-3 w-3" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-64 p-2" align="start">
-          <div className="grid grid-cols-5 gap-1">
-            {QUICK_REACTIONS.map((reaction) => (
-              <Button
-                key={reaction.emoji}
-                variant="ghost"
-                size="sm"
-                onClick={() => handleEmojiSelect(reaction.emoji)}
-                className="h-10 w-10 text-xl hover:bg-accent"
-                title={reaction.label}
-              >
-                {reaction.emoji}
-              </Button>
-            ))}
-          </div>
-          <div className="mt-2 pt-2 border-t">
-            <p className="text-xs text-muted-foreground text-center">
-              クリックしてリアクションを追加
-            </p>
-          </div>
-        </PopoverContent>
-      </Popover>
+      {onAddReaction && (
+        <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+            >
+              <Smile className="h-3 w-3" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-64 p-2" align="start">
+            <div className="grid grid-cols-5 gap-1">
+              {QUICK_REACTIONS.map((reaction) => (
+                <Button
+                  key={reaction.emoji}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleEmojiSelect(reaction.emoji)}
+                  className="h-10 w-10 text-xl hover:bg-accent"
+                  title={reaction.label}
+                >
+                  {reaction.emoji}
+                </Button>
+              ))}
+            </div>
+            <div className="mt-2 pt-2 border-t">
+              <p className="text-xs text-muted-foreground text-center">
+                {t('chat.reactions.addPrompt')}
+              </p>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
     </div>
   );
 }

--- a/client/src/hooks/useRealtimeMessages.ts
+++ b/client/src/hooks/useRealtimeMessages.ts
@@ -24,30 +24,30 @@ export function useRealtimeMessages({ channelId, enabled = true }: UseRealtimeMe
 
   const handleNewMessage = useCallback((payload: any) => {
     console.log("📨 New message received:", payload);
-    
+
     // Query キャッシュを無効化して最新メッセージを取得
-    queryClient.invalidateQueries({ 
-      queryKey: ["chatMessages", "channel", channelId] 
+    queryClient.invalidateQueries({
+      queryKey: ["chatMessages", currentWorkspaceId ?? "", "channel", channelId]
     });
-  }, [channelId]);
+  }, [channelId, currentWorkspaceId]);
 
   const handleMessageUpdate = useCallback((payload: any) => {
     console.log("✏️ Message updated:", payload);
-    
+
     // Query キャッシュを無効化
-    queryClient.invalidateQueries({ 
-      queryKey: ["chatMessages", "channel", channelId] 
+    queryClient.invalidateQueries({
+      queryKey: ["chatMessages", currentWorkspaceId ?? "", "channel", channelId]
     });
-  }, [channelId]);
+  }, [channelId, currentWorkspaceId]);
 
   const handleMessageDelete = useCallback((payload: any) => {
     console.log("🗑️ Message deleted:", payload);
-    
+
     // Query キャッシュを無効化
-    queryClient.invalidateQueries({ 
-      queryKey: ["chatMessages", "channel", channelId] 
+    queryClient.invalidateQueries({
+      queryKey: ["chatMessages", currentWorkspaceId ?? "", "channel", channelId]
     });
-  }, [channelId]);
+  }, [channelId, currentWorkspaceId]);
 
   useEffect(() => {
     // 購読が無効、またはワークスペース/チャンネルIDがない場合は早期リターン

--- a/client/src/lib/chatAttachments.ts
+++ b/client/src/lib/chatAttachments.ts
@@ -1,0 +1,69 @@
+import { supabase, isSupabaseConfigured } from '@/lib/supabase';
+
+interface UploadOptions {
+  workspaceId: string;
+  channelId: string;
+}
+
+export interface UploadResult {
+  fileName: string;
+  fileUrl: string;
+  fileSize: number;
+  mimeType: string;
+}
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_.-]/g, '_');
+}
+
+async function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+export async function uploadChatAttachment(file: File, options: UploadOptions): Promise<UploadResult> {
+  const { workspaceId, channelId } = options;
+  const sanitizedName = sanitizeFileName(file.name);
+  const timestamp = Date.now();
+  const storagePath = `${workspaceId}/${channelId}/${timestamp}-${sanitizedName}`;
+
+  if (isSupabaseConfigured()) {
+    const { error } = await supabase.storage
+      .from('chat-attachments')
+      .upload(storagePath, file, {
+        cacheControl: '3600',
+        upsert: false,
+        contentType: file.type,
+      });
+
+    if (error) {
+      console.error('Failed to upload attachment to Supabase Storage', error);
+      throw new Error(error.message || 'Unable to upload attachment');
+    }
+
+    const { data } = supabase.storage.from('chat-attachments').getPublicUrl(storagePath);
+    if (!data?.publicUrl) {
+      throw new Error('Unable to resolve attachment URL');
+    }
+
+    return {
+      fileName: file.name,
+      fileUrl: data.publicUrl,
+      fileSize: file.size,
+      mimeType: file.type,
+    };
+  }
+
+  // Development fallback: embed file as data URL so attachments remain functional without Supabase.
+  const dataUrl = await readFileAsDataUrl(file);
+  return {
+    fileName: file.name,
+    fileUrl: dataUrl,
+    fileSize: file.size,
+    mimeType: file.type,
+  };
+}

--- a/client/src/locales/en.ts
+++ b/client/src/locales/en.ts
@@ -2663,6 +2663,24 @@ export const en = {
         flag: "Report",
         delete: "Delete",
       },
+      attachmentPlaceholder: "Attachment",
+      attachmentUploadFailed: "Failed to upload attachment",
+      tryAgain: "Please try again.",
+      sendError: "We couldn't send your message",
+      selectWorkspace: "Select a workspace and try again.",
+      reactionFailed: "Failed to update reaction",
+      unreadSeparator: "New messages",
+      you: "You",
+      attachments: {
+        imageAlt: "Preview of {{fileName}}",
+      },
+    },
+    filters: {
+      unreadOnly: "Unread only",
+      threadsOnly: "Threads only",
+    },
+    reactions: {
+      addPrompt: "Click to add a reaction",
     },
   },
   workspace: {

--- a/client/src/locales/ja.ts
+++ b/client/src/locales/ja.ts
@@ -2737,6 +2737,24 @@ export const ja = {
         flag: "報告",
         delete: "削除",
       },
+      attachmentPlaceholder: "添付ファイル",
+      attachmentUploadFailed: "添付ファイルのアップロードに失敗しました",
+      tryAgain: "もう一度お試しください。",
+      sendError: "メッセージを送信できませんでした",
+      selectWorkspace: "ワークスペースを選択してからもう一度お試しください。",
+      reactionFailed: "リアクションの更新に失敗しました",
+      unreadSeparator: "新着メッセージ",
+      you: "あなた",
+      attachments: {
+        imageAlt: "{{fileName}} のプレビュー",
+      },
+    },
+    filters: {
+      unreadOnly: "未読のみ",
+      threadsOnly: "スレッドのみ",
+    },
+    reactions: {
+      addPrompt: "クリックしてリアクションを追加",
     },
   },
   workspace: {

--- a/client/src/pages/Chat.tsx
+++ b/client/src/pages/Chat.tsx
@@ -14,9 +14,15 @@ import { useRoute } from "wouter";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { cn } from "@/lib/utils";
 import { matchFaq, type FaqEntry } from "@/data/faqs";
-import type { ChatMessage as ChatMessageType } from "@shared/schema";
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
-import type { MessageModalContext } from "@/types";
+import type {
+  MessageModalContext,
+  ChatMessagesResponse,
+  ChatMessageWithExtrasDto,
+  ChatAttachmentDto,
+  ChatReactionSummaryDto,
+  ChatReadReceiptDto,
+} from "@/types";
 import { useAuth } from "@/contexts/AuthContext";
 import { useWorkspaceData } from "@/contexts/WorkspaceDataContext";
 import { toast } from "@/hooks/use-toast";
@@ -24,6 +30,8 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useRealtimeMessages } from "@/hooks/useRealtimeMessages";
 import { useOnlinePresence } from "@/hooks/useOnlinePresence";
 import { isSupabaseConfigured } from "@/lib/supabase";
+import { uploadChatAttachment } from "@/lib/chatAttachments";
+import { useTranslation } from "@/contexts/LanguageContext";
 
 interface ChannelInfo {
   name: string;
@@ -45,7 +53,27 @@ interface DisplayMessage {
   threadCount?: number;
   lastThreadReply?: Date;
   isFirstUnread?: boolean;
+  attachments: ChatAttachmentDto[];
+  reactions: (ChatReactionSummaryDto & { hasReacted: boolean })[];
 }
+
+type SendMessageContext = {
+  previousChannelTimeline?: ChatMessagesResponse;
+  previousAggregatedTimeline?: ChatMessagesResponse;
+  optimisticId?: string;
+};
+
+type PendingAttachmentInput = {
+  fileName: string;
+  fileUrl: string;
+  fileSize: number;
+  mimeType: string;
+};
+
+type SendMessageInput = {
+  content: string;
+  attachments: PendingAttachmentInput[];
+};
 
 // Mock channel info until we have channels API
 const getChannelInfo = (channelId: string): ChannelInfo => {
@@ -63,6 +91,7 @@ export default function Chat() {
   const currentUserId = user?.id ?? "user-1";
   const currentUserName = user?.name ?? "You";
   const { createTask: createWorkspaceTask, createKnowledge: createWorkspaceKnowledge } = useWorkspaceData();
+  const { t } = useTranslation();
 
   const isMobile = useIsMobile();
 
@@ -116,56 +145,110 @@ export default function Chat() {
       setSelectedThread(null);
       setThreadMessages([]);
     }
-    unreadCutoffRef.current = new Date(Date.now() - 30 * 60 * 1000);
   }, [channelId]);
-  
+
   // Ref for auto-scrolling
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const unreadCutoffRef = useRef<Date>(new Date(Date.now() - 30 * 60 * 1000));
   
   const messagesQueryKey = useMemo(() => {
-    if (isChannelContext) {
-      return ["chatMessages", "channel", channelId ?? "general"];
+    if (!currentWorkspaceId) {
+      return null;
     }
-    return ["chatMessages", "conversation", contextId];
-  }, [isChannelContext, channelId, contextId]);
+    if (isChannelContext) {
+      return ["chatMessages", currentWorkspaceId, "channel", channelId ?? "general"] as const;
+    }
+    return ["chatMessages", currentWorkspaceId, "conversation", contextId] as const;
+  }, [currentWorkspaceId, isChannelContext, channelId, contextId]);
 
-  const { data: rawMessages = [], isLoading: isLoadingMessages, isError: isMessagesError } = useQuery<ChatMessageType[]>({
-    queryKey: messagesQueryKey,
+  const aggregatedMessagesQueryKey = useMemo(() => {
+    return currentWorkspaceId ? (["/api/messages", currentWorkspaceId] as const) : null;
+  }, [currentWorkspaceId]);
+
+  const { data: timeline, isLoading: isLoadingMessages, isError: isMessagesError } = useQuery<ChatMessagesResponse>({
+    queryKey: messagesQueryKey ?? ["chatMessages", "unscoped"],
+    enabled: Boolean(messagesQueryKey && currentWorkspaceId),
     queryFn: async () => {
-      const querySuffix = isChannelContext && channelId ? `?channelId=${channelId}` : "";
-      const response = await fetch(`/api/messages${querySuffix}`, { credentials: "include" });
+      if (!currentWorkspaceId) {
+        return { messages: [], unreadCount: 0, readReceipt: null } satisfies ChatMessagesResponse;
+      }
+      const params = new URLSearchParams({ workspaceId: currentWorkspaceId, userId: currentUserId });
+      if (isChannelContext && channelId) {
+        params.set("channelId", channelId);
+      }
+      const response = await fetch(`/api/messages?${params.toString()}`, { credentials: "include" });
       if (!response.ok) {
         const errorText = await response.text();
         throw new Error(errorText || response.statusText);
       }
-  return (await response.json()) as ChatMessageType[];
+      return (await response.json()) as ChatMessagesResponse;
     },
   });
 
+  const rawMessages = useMemo<ChatMessageWithExtrasDto[]>(() => timeline?.messages ?? [], [timeline]);
+  const readReceipt = timeline?.readReceipt ?? null;
+  const unreadCount = timeline?.unreadCount ?? 0;
+
+  const updateMessageReactions = useCallback((messageId: string, reactions: ChatReactionSummaryDto[]) => {
+    if (messagesQueryKey) {
+      queryClient.setQueryData<ChatMessagesResponse>(messagesQueryKey, (old) => {
+        if (!old) {
+          return old;
+        }
+        return {
+          ...old,
+          messages: old.messages.map((message) =>
+            message.id === messageId ? { ...message, reactions } : message
+          ),
+        };
+      });
+    }
+    if (aggregatedMessagesQueryKey) {
+      queryClient.setQueryData<ChatMessagesResponse>(aggregatedMessagesQueryKey, (old) => {
+        if (!old) {
+          return old;
+        }
+        return {
+          ...old,
+          messages: old.messages.map((message) =>
+            message.id === messageId ? { ...message, reactions } : message
+          ),
+        };
+      });
+    }
+  }, [messagesQueryKey, aggregatedMessagesQueryKey]);
+
   const messages = useMemo<DisplayMessage[]>(() => {
-    const unreadCutoff = unreadCutoffRef.current;
+    const lastReadAt = readReceipt?.lastReadAt ? new Date(readReceipt.lastReadAt) : null;
     return rawMessages
       .map((message): DisplayMessage => {
-        // Safe date parsing: handle both Date objects and ISO strings
         let timestamp: Date;
         try {
-          timestamp = message.createdAt instanceof Date 
-            ? message.createdAt 
+          timestamp = message.createdAt instanceof Date
+            ? message.createdAt
             : new Date(message.createdAt);
-          
-          // Validate the date
+
           if (isNaN(timestamp.getTime())) {
             console.warn('Invalid timestamp for message:', message.id, message.createdAt);
-            timestamp = new Date(); // Fallback to current time
+            timestamp = new Date();
           }
         } catch (error) {
           console.error('Error parsing timestamp:', error);
           timestamp = new Date();
         }
-        
+
         const isOwn = message.userId === currentUserId;
-        const isUnread = !isOwn && timestamp > unreadCutoff;
+        const isUnread = !isOwn && (!lastReadAt || timestamp > lastReadAt);
+
+        const attachments: ChatAttachmentDto[] = (message.attachments ?? []).map((attachment) => ({
+          ...attachment,
+          uploadedAt: attachment.uploadedAt ?? new Date(),
+        }));
+
+        const reactions = (message.reactions ?? []).map((reaction) => ({
+          ...reaction,
+          hasReacted: reaction.userIds.includes(currentUserId),
+        }));
+
         return {
           id: message.id,
           userId: message.userId,
@@ -175,12 +258,14 @@ export default function Chat() {
           timestamp,
           isOwn,
           isUnread,
-          isPending: (message as any).isPending || false, // 送信中フラグを保持
+          isPending: (message as any).isPending || false,
           threadCount: 0,
+          attachments,
+          reactions,
         };
       })
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-  }, [rawMessages, currentUserId]);
+  }, [rawMessages, currentUserId, readReceipt]);
 
 // Apply filters and identify first unread message
   const filteredMessages = messages.filter(message => {
@@ -202,71 +287,252 @@ export default function Chat() {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages.length]);
+
+  useEffect(() => {
+    if (!channelId || !currentWorkspaceId || rawMessages.length === 0) {
+      return;
+    }
+    const lastMessage = rawMessages[rawMessages.length - 1];
+    const timestamp = lastMessage.createdAt instanceof Date
+      ? lastMessage.createdAt
+      : new Date(lastMessage.createdAt);
+    const lastReadAtTime = readReceipt?.lastReadAt ? new Date(readReceipt.lastReadAt).getTime() : 0;
+
+    if (!isNaN(timestamp.getTime()) && timestamp.getTime() > lastReadAtTime && !isMarkingRead) {
+      markRead({ messageId: lastMessage.id, timestamp });
+    }
+  }, [rawMessages, readReceipt, channelId, currentWorkspaceId, markRead, isMarkingRead]);
   
   // Send message mutation
-  const sendMessageMutation = useMutation({
-    mutationFn: async (content: string) => {
+  const sendMessageMutation = useMutation<ChatMessageWithExtrasDto, unknown, SendMessageInput, SendMessageContext>({
+    mutationFn: async ({ content, attachments }) => {
       if (!currentWorkspaceId) {
         throw new Error("Workspace ID is required");
       }
       if (!channelId) {
         throw new Error("Channel ID is required");
       }
-      
-      return apiRequest("POST", "/api/messages", {
+
+      const response = await apiRequest("POST", "/api/messages", {
         workspaceId: currentWorkspaceId,
         channelId,
         content,
         userId: currentUserId,
         userName: currentUserName,
+        attachments,
       });
+
+      return (await response.json()) as ChatMessageWithExtrasDto;
     },
-    onMutate: async (content: string) => {
-      // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: ["/api/messages"] });
-      
-      // Snapshot the previous value
-      const previousMessages = queryClient.getQueryData(["/api/messages"]);
-      
-      // Optimistically update to the new value
-      const optimisticMessage = {
-        id: `temp-${Date.now()}`,
+    onMutate: async ({ content, attachments }) => {
+      if (!messagesQueryKey || !aggregatedMessagesQueryKey || !currentWorkspaceId || !channelId) {
+        return {};
+      }
+
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: messagesQueryKey }),
+        queryClient.cancelQueries({ queryKey: aggregatedMessagesQueryKey }),
+      ]);
+
+      const previousChannelTimeline = queryClient.getQueryData<ChatMessagesResponse>(messagesQueryKey);
+      const previousAggregatedTimeline = queryClient.getQueryData<ChatMessagesResponse>(aggregatedMessagesQueryKey);
+
+      const optimisticId = `temp-${Date.now()}`;
+      const createdAt = new Date();
+
+      const optimisticMessage: ChatMessageWithExtrasDto = {
+        id: optimisticId,
         workspaceId: currentWorkspaceId,
         channelId,
         userId: currentUserId,
         userName: currentUserName,
         content,
-        createdAt: new Date(),
+        createdAt,
         parentMessageId: null,
         editedAt: null,
         deletedAt: null,
-        isPending: true, // フラグで送信中を示す
+        attachments: attachments.map((attachment, index) => ({
+          id: `temp-attachment-${optimisticId}-${index}`,
+          messageId: optimisticId,
+          fileName: attachment.fileName,
+          fileUrl: attachment.fileUrl,
+          fileSize: attachment.fileSize,
+          mimeType: attachment.mimeType,
+          uploadedAt: createdAt,
+        })),
+        reactions: [],
       };
-      
-      queryClient.setQueryData(["/api/messages"], (old: any) => {
-        if (!old) return [optimisticMessage];
-        return [...old, optimisticMessage];
+
+      queryClient.setQueryData<ChatMessagesResponse>(messagesQueryKey, (old) => {
+        const base = old ?? { messages: [], unreadCount: timeline?.unreadCount ?? 0, readReceipt: readReceipt ?? null };
+        return {
+          ...base,
+          messages: [...base.messages, { ...optimisticMessage, isPending: true } as ChatMessageWithExtrasDto],
+        };
       });
-      
-      // Return a context object with the snapshotted value
-      return { previousMessages };
+
+      queryClient.setQueryData<ChatMessagesResponse>(aggregatedMessagesQueryKey, (old) => {
+        const base = old ?? { messages: [], unreadCount: 0, readReceipt: null };
+        return {
+          ...base,
+          messages: [...base.messages, { ...optimisticMessage, isPending: true } as ChatMessageWithExtrasDto],
+        };
+      });
+
+      return {
+        previousChannelTimeline,
+        previousAggregatedTimeline,
+        optimisticId,
+      };
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["chatMessages"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/messages"] });
-    },
-    onError: (error: unknown, _content, context) => {
-      // Rollback to the previous value on error
-      if (context?.previousMessages) {
-        queryClient.setQueryData(["/api/messages"], context.previousMessages);
+    onError: (error, _variables, context) => {
+      if (messagesQueryKey && context?.previousChannelTimeline) {
+        queryClient.setQueryData(messagesQueryKey, context.previousChannelTimeline);
       }
-      
-      const description = error instanceof Error ? error.message : 'Please try again.';
+      if (aggregatedMessagesQueryKey && context?.previousAggregatedTimeline) {
+        queryClient.setQueryData(aggregatedMessagesQueryKey, context.previousAggregatedTimeline);
+      }
+
+      const description = error instanceof Error ? error.message : "Please try again.";
       toast({
         title: "Failed to send message",
         description,
         variant: "destructive",
       });
+    },
+    onSuccess: (savedMessage, _variables, context) => {
+      if (messagesQueryKey) {
+        queryClient.setQueryData<ChatMessagesResponse>(messagesQueryKey, (old) => {
+          if (!old) {
+            return old;
+          }
+          const updatedMessages = old.messages.some((message) => message.id === context?.optimisticId)
+            ? old.messages.map((message) =>
+                message.id === context?.optimisticId
+                  ? { ...savedMessage }
+                  : message,
+              )
+            : [...old.messages, savedMessage];
+
+          return {
+            ...old,
+            messages: updatedMessages,
+          };
+        });
+      }
+
+      if (aggregatedMessagesQueryKey) {
+        queryClient.setQueryData<ChatMessagesResponse>(aggregatedMessagesQueryKey, (old) => {
+          if (!old) {
+            return old;
+          }
+          const updatedMessages = old.messages.some((message) => message.id === context?.optimisticId)
+            ? old.messages.map((message) =>
+                message.id === context?.optimisticId
+                  ? { ...savedMessage }
+                  : message,
+              )
+            : [...old.messages, savedMessage];
+
+          return {
+            ...old,
+            messages: updatedMessages,
+          };
+        });
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["chatMessages"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/messages"] });
+    },
+  });
+
+  const addReactionMutation = useMutation<ChatReactionSummaryDto[], unknown, { messageId: string; emoji: string }>({
+    mutationFn: async ({ messageId, emoji }) => {
+      if (!currentWorkspaceId || !channelId) {
+        throw new Error("Workspace and channel are required");
+      }
+      const response = await apiRequest("POST", `/api/messages/${messageId}/reactions`, {
+        workspaceId: currentWorkspaceId,
+        channelId,
+        userId: currentUserId,
+        emoji,
+      });
+      return (await response.json()) as ChatReactionSummaryDto[];
+    },
+    onSuccess: (reactions, variables) => {
+      updateMessageReactions(variables.messageId, reactions);
+    },
+    onError: (error) => {
+      const description = error instanceof Error ? error.message : t("chat.message.tryAgain");
+      toast({
+        title: t("chat.message.reactionFailed"),
+        description,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const removeReactionMutation = useMutation<ChatReactionSummaryDto[], unknown, { messageId: string; emoji: string }>({
+    mutationFn: async ({ messageId, emoji }) => {
+      const params = new URLSearchParams({ userId: currentUserId, emoji });
+      const response = await fetch(`/api/messages/${messageId}/reactions?${params.toString()}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || response.statusText);
+      }
+      return (await response.json()) as ChatReactionSummaryDto[];
+    },
+    onSuccess: (reactions, variables) => {
+      updateMessageReactions(variables.messageId, reactions);
+    },
+    onError: (error) => {
+      const description = error instanceof Error ? error.message : t("chat.message.tryAgain");
+      toast({
+        title: t("chat.message.reactionFailed"),
+        description,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const { mutate: markRead, isPending: isMarkingRead } = useMutation<void, unknown, { messageId: string; timestamp: Date }>({
+    mutationFn: async ({ messageId, timestamp }) => {
+      if (!channelId || !currentWorkspaceId) {
+        return;
+      }
+      await apiRequest("POST", "/api/messages/read-receipts", {
+        workspaceId: currentWorkspaceId,
+        userId: currentUserId,
+        channelId,
+        lastReadMessageId: messageId,
+        lastReadAt: timestamp,
+      });
+    },
+    onSuccess: (_data, variables) => {
+      if (messagesQueryKey) {
+        queryClient.setQueryData<ChatMessagesResponse>(messagesQueryKey, (old) => {
+          if (!old) {
+            return old;
+          }
+          const updatedReceipt: ChatReadReceiptDto = {
+            id: old.readReceipt?.id ?? `temp-${currentUserId}-${channelId}`,
+            workspaceId: currentWorkspaceId,
+            userId: currentUserId,
+            channelId: channelId ?? "",
+            lastReadMessageId: variables.messageId,
+            lastReadAt: variables.timestamp,
+          };
+          return {
+            ...old,
+            readReceipt: updatedReceipt,
+            unreadCount: 0,
+          };
+        });
+      }
     },
   });
   
@@ -304,15 +570,52 @@ Knowledge: ${KNOWLEDGE_ROUTE_BASE}/${faq.relatedKnowledgeId}` : "");
     }
   }, [currentWorkspaceId, channelId, toast]);
 
-  const handleSendMessage = (content: string) => {
-    const faqMatch = matchFaq(content);
-    sendMessageMutation.mutate(content, {
-      onSuccess: () => {
-        if (faqMatch) {
-          handleFaqResponse(faqMatch);
-        }
-      },
-    });
+  const handleSendMessage = async (content: string, file?: File | null) => {
+    if (!currentWorkspaceId || !channelId) {
+      toast({
+        title: t("chat.message.sendError"),
+        description: t("chat.message.selectWorkspace"),
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const trimmedContent = content.trim();
+    const faqMatch = trimmedContent ? matchFaq(trimmedContent) : null;
+    const attachments: PendingAttachmentInput[] = [];
+
+    if (file) {
+      try {
+        const uploaded = await uploadChatAttachment(file, {
+          workspaceId: currentWorkspaceId,
+          channelId,
+        });
+        attachments.push(uploaded);
+      } catch (error) {
+        const description = error instanceof Error ? error.message : t("chat.message.tryAgain");
+        toast({
+          title: t("chat.message.attachmentUploadFailed"),
+          description,
+          variant: "destructive",
+        });
+        return;
+      }
+    }
+
+    const messageContent = trimmedContent || t("chat.message.attachmentPlaceholder");
+
+    try {
+      await sendMessageMutation.mutateAsync({
+        content: messageContent,
+        attachments,
+      });
+
+      if (faqMatch) {
+        await handleFaqResponse(faqMatch);
+      }
+    } catch (error) {
+      // エラーハンドリングはmutation内で実施
+    }
   };
   
   const channelInfo = isChannelContext 
@@ -332,6 +635,14 @@ Knowledge: ${KNOWLEDGE_ROUTE_BASE}/${faq.relatedKnowledgeId}` : "");
       authorName: message.userName,
       channelId: message.channelId ?? undefined,
     });
+  };
+
+  const handleAddReaction = (messageId: string, emoji: string) => {
+    addReactionMutation.mutate({ messageId, emoji });
+  };
+
+  const handleRemoveReaction = (messageId: string, emoji: string) => {
+    removeReactionMutation.mutate({ messageId, emoji });
   };
 
   const handleTaskCreate = (taskData: NewTaskData) => {
@@ -405,6 +716,15 @@ Knowledge: ${KNOWLEDGE_ROUTE_BASE}/${faq.relatedKnowledgeId}` : "");
   };
 
   const handleShareKnowledge = async (knowledgeId: string, title: string, summary: string) => {
+    if (!currentWorkspaceId) {
+      toast({
+        title: "Unable to share",
+        description: "Select a workspace and try again.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     const message = `Knowledge share: ${title}
 
 ${summary}
@@ -412,6 +732,7 @@ ${summary}
 ${KNOWLEDGE_ROUTE_BASE}/${knowledgeId}`;
     try {
       await apiRequest("POST", "/api/messages", {
+        workspaceId: currentWorkspaceId,
         content: message,
         userId: currentUserId,
         userName: currentUserName,
@@ -471,10 +792,10 @@ ${KNOWLEDGE_ROUTE_BASE}/${knowledgeId}`;
     setThreadMessages([]);
   };
 
-  const handleSendThreadReply = async (content: string) => {
+  const handleSendThreadReply = async (content: string, _file?: File | null) => {
     if (!selectedThread) return;
-    
-    
+
+
     // Mock sending thread reply - in real app, this would be an API call
     const newReply = {
       id: `thread-${selectedThread}-${Date.now()}`,
@@ -650,10 +971,10 @@ ${KNOWLEDGE_ROUTE_BASE}/${knowledgeId}`;
                     isMobile && "min-w-[6.5rem] justify-center"
                   )}
                 >
-                  Unread only
-                  {messages.filter(m => m.isUnread).length > 0 && (
+                  {t("chat.filters.unreadOnly")}
+                  {unreadCount > 0 && (
                     <Badge variant="destructive" className="ml-1 h-4 w-4 p-0 text-xs">
-                      {messages.filter(m => m.isUnread).length}
+                      {unreadCount}
                     </Badge>
                   )}
                 </Button>
@@ -666,7 +987,7 @@ ${KNOWLEDGE_ROUTE_BASE}/${knowledgeId}`;
                     isMobile && "min-w-[6.5rem] justify-center"
                   )}
                 >
-                  Threads only
+                  {t("chat.filters.threadsOnly")}
                   {messages.filter(m => m.threadCount).length > 0 && (
                     <Badge variant="secondary" className="ml-1 h-4 w-4 p-0 text-xs">
                       {messages.filter(m => m.threadCount).length}
@@ -717,6 +1038,9 @@ ${KNOWLEDGE_ROUTE_BASE}/${knowledgeId}`;
                   onRequestKnowledgeCreation={handleRequestKnowledgeCreation}
                   onReply={handleReply}
                   onViewThread={handleViewThread}
+                  onAddReaction={handleAddReaction}
+                  onRemoveReaction={handleRemoveReaction}
+                  disableReactions={addReactionMutation.isPending || removeReactionMutation.isPending}
                 />
               ))
             )}

--- a/client/src/pages/Knowledge.tsx
+++ b/client/src/pages/Knowledge.tsx
@@ -55,7 +55,7 @@ export default function Knowledge() {
   const [createModalOpen, setCreateModalOpen] = useState(false);
 
   const { knowledgeArticles, getParticipantById, updateKnowledge, deleteKnowledge, createKnowledge } = useWorkspaceData();
-  const { user } = useAuth();
+  const { user, currentWorkspaceId } = useAuth();
 
   const currentUserId = user?.id ?? "user-1";
   const currentUserName = user?.name ?? "You";
@@ -280,8 +280,14 @@ ${summary}
 
 [View full article](${KNOWLEDGE_ROUTE_BASE}/${article.id})`;
 
+    if (!currentWorkspaceId) {
+      toast({ title: "Unable to share", description: "Select a workspace and try again.", variant: "destructive" });
+      return;
+    }
+
     try {
       await apiRequest("POST", "/api/messages", {
+        workspaceId: currentWorkspaceId,
         content: message,
         userId: currentUserId,
         userName: currentUserName,
@@ -319,8 +325,14 @@ ${summary}
 
 [View full article](${KNOWLEDGE_ROUTE_BASE}/${article.id})`;
 
+    if (!currentWorkspaceId) {
+      toast({ title: "Unable to share", description: "Select a workspace and try again.", variant: "destructive" });
+      return;
+    }
+
     try {
       await apiRequest("POST", "/api/messages", {
+        workspaceId: currentWorkspaceId,
         content: message,
         userId: currentUserId,
         userName: currentUserName,

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -1,0 +1,17 @@
+import type {
+  ChatAttachment,
+  ChatMessageWithExtras,
+  ChatMessagesResponse as SharedChatMessagesResponse,
+  ChatReactionSummary,
+  ChatReadReceipt,
+} from '@shared/schema';
+
+export type ChatReactionSummaryDto = ChatReactionSummary;
+
+export type ChatMessageWithExtrasDto = ChatMessageWithExtras & { isPending?: boolean };
+
+export interface ChatMessagesResponse extends SharedChatMessagesResponse {}
+
+export type ChatAttachmentDto = ChatAttachment;
+
+export type ChatReadReceiptDto = ChatReadReceipt;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -4,3 +4,5 @@ export interface MessageModalContext {
   authorName: string;
   channelId?: string;
 }
+
+export * from './chat';

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -231,7 +231,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Tasks API
   app.get("/api/tasks", async (req, res) => {
     try {
-      const tasks = await storage.getTasks();
+      const { workspaceId } = req.query;
+
+      if (!workspaceId || typeof workspaceId !== "string") {
+        return res.status(400).json({ error: "workspaceId is required" });
+      }
+
+      const tasks = await storage.getTasks(workspaceId);
       res.json(tasks);
     } catch (error) {
       handleError(error, "get tasks", res);
@@ -288,7 +294,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Knowledge Articles API
   app.get("/api/knowledge", async (req, res) => {
     try {
-      const articles = await storage.getKnowledgeArticles();
+      const { workspaceId } = req.query;
+
+      if (!workspaceId || typeof workspaceId !== "string") {
+        return res.status(400).json({ error: "workspaceId is required" });
+      }
+
+      const articles = await storage.getKnowledgeArticles(workspaceId);
       res.json(articles);
     } catch (error) {
       handleError(error, "get knowledge articles", res);
@@ -330,7 +342,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Meetings API
   app.get("/api/meetings", async (req, res) => {
     try {
-      const meetings = await storage.getMeetings();
+      const { workspaceId } = req.query;
+
+      if (!workspaceId || typeof workspaceId !== "string") {
+        return res.status(400).json({ error: "workspaceId is required" });
+      }
+
+      const meetings = await storage.getMeetings(workspaceId);
       res.json(meetings);
     } catch (error) {
       handleError(error, "get meetings", res);
@@ -393,16 +411,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ error: "workspaceId is required" });
       }
 
-      const [messages, tasks, knowledge, meetings] = await Promise.all([
+      const [messages, workspaceTasks, workspaceKnowledge, workspaceMeetings] = await Promise.all([
         storage.getChatMessages(workspaceId),
-        storage.getTasks(),
-        storage.getKnowledgeArticles(),
-        storage.getMeetings()
+        storage.getTasks(workspaceId),
+        storage.getKnowledgeArticles(workspaceId),
+        storage.getMeetings(workspaceId)
       ]);
-
-      const workspaceTasks = tasks.filter(task => task.workspaceId === workspaceId);
-      const workspaceKnowledge = knowledge.filter(article => article.workspaceId === workspaceId);
-      const workspaceMeetings = meetings.filter(meeting => meeting.workspaceId === workspaceId);
 
       const now = new Date();
       const upcomingMeetings = workspaceMeetings.filter(m =>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -84,12 +84,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       let readReceipt: ChatMessagesResponse["readReceipt"] = null;
       let unreadCount = 0;
 
-      if (
-        typeof userId === "string" &&
-        typeof channelId === "string" &&
-        channelFilter
-      ) {
-        const receipt = await storage.getReadReceipt(workspaceId, userId, channelFilter);
+      if (typeof userId === "string" && typeof channelId === "string") {
+        const receipt = await storage.getReadReceipt(workspaceId, userId, channelId);
         if (receipt) {
           readReceipt = receipt;
         }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -212,10 +212,6 @@ export class MemStorage implements IStorage {
       lastReadAt: now,
     };
 
-    if (receipt.lastReadMessageId) {
-      record.lastReadMessageId = receipt.lastReadMessageId;
-    }
-
     this.chatReadReceipts.set(key, record);
     return record;
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -35,19 +35,19 @@ export interface IStorage {
   upsertReadReceipt(receipt: InsertChatReadReceipt & { lastReadAt?: Date }): Promise<ChatReadReceipt>;
 
   // Tasks
-  getTasks(): Promise<Task[]>;
+  getTasks(workspaceId: string): Promise<Task[]>;
   getTask(id: string): Promise<Task | undefined>;
   createTask(task: InsertTask): Promise<Task>;
   updateTask(id: string, updates: Partial<InsertTask>): Promise<Task | undefined>;
 
   // Knowledge Articles
-  getKnowledgeArticles(): Promise<KnowledgeArticle[]>;
+  getKnowledgeArticles(workspaceId: string): Promise<KnowledgeArticle[]>;
   getKnowledgeArticle(id: string): Promise<KnowledgeArticle | undefined>;
   createKnowledgeArticle(article: InsertKnowledgeArticle): Promise<KnowledgeArticle>;
   incrementArticleViews(id: string): Promise<void>;
 
   // Meetings
-  getMeetings(): Promise<Meeting[]>;
+  getMeetings(workspaceId: string): Promise<Meeting[]>;
   getMeeting(id: string): Promise<Meeting | undefined>;
   createMeeting(meeting: InsertMeeting): Promise<Meeting>;
   updateMeeting(id: string, updates: Partial<InsertMeeting>): Promise<Meeting | undefined>;
@@ -221,10 +221,10 @@ export class MemStorage implements IStorage {
   }
 
   // Tasks
-  async getTasks(): Promise<Task[]> {
-    return Array.from(this.tasks.values()).sort((a, b) => 
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
+  async getTasks(workspaceId: string): Promise<Task[]> {
+    return Array.from(this.tasks.values())
+      .filter((task) => task.workspaceId === workspaceId)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   }
 
   async getTask(id: string): Promise<Task | undefined> {
@@ -256,10 +256,10 @@ export class MemStorage implements IStorage {
   }
 
   // Knowledge Articles
-  async getKnowledgeArticles(): Promise<KnowledgeArticle[]> {
-    return Array.from(this.knowledgeArticles.values()).sort((a, b) => 
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
+  async getKnowledgeArticles(workspaceId: string): Promise<KnowledgeArticle[]> {
+    return Array.from(this.knowledgeArticles.values())
+      .filter((article) => article.workspaceId === workspaceId)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
   }
 
   async getKnowledgeArticle(id: string): Promise<KnowledgeArticle | undefined> {
@@ -291,10 +291,10 @@ export class MemStorage implements IStorage {
   }
 
   // Meetings
-  async getMeetings(): Promise<Meeting[]> {
-    return Array.from(this.meetings.values()).sort((a, b) => 
-      new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
-    );
+  async getMeetings(workspaceId: string): Promise<Meeting[]> {
+    return Array.from(this.meetings.values())
+      .filter((meeting) => meeting.workspaceId === workspaceId)
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
   }
 
   async getMeeting(id: string): Promise<Meeting | undefined> {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,6 +1,9 @@
-import { 
+import {
   type User, type InsertUser,
   type ChatMessage, type InsertChatMessage,
+  type ChatAttachment, type InsertChatAttachment,
+  type ChatReaction, type InsertChatReaction,
+  type ChatReadReceipt, type InsertChatReadReceipt,
   type Task, type InsertTask,
   type KnowledgeArticle, type InsertKnowledgeArticle,
   type Meeting, type InsertMeeting
@@ -21,8 +24,15 @@ export interface IStorage {
   createUser(user: InsertUser): Promise<User>;
 
   // Chat Messages
-  getChatMessages(channelId?: string): Promise<ChatMessage[]>;
+  getChatMessages(workspaceId: string, channelId?: string): Promise<ChatMessage[]>;
   createChatMessage(message: InsertChatMessage): Promise<ChatMessage>;
+  createChatAttachment(attachment: InsertChatAttachment): Promise<ChatAttachment>;
+  getChatAttachments(messageIds: string[]): Promise<ChatAttachment[]>;
+  addChatReaction(reaction: InsertChatReaction): Promise<ChatReaction>;
+  removeChatReaction(messageId: string, userId: string, emoji: string): Promise<void>;
+  getChatReactions(messageIds: string[]): Promise<ChatReaction[]>;
+  getReadReceipt(workspaceId: string, userId: string, channelId: string): Promise<ChatReadReceipt | undefined>;
+  upsertReadReceipt(receipt: InsertChatReadReceipt & { lastReadAt?: Date }): Promise<ChatReadReceipt>;
 
   // Tasks
   getTasks(): Promise<Task[]>;
@@ -46,6 +56,9 @@ export interface IStorage {
 export class MemStorage implements IStorage {
   private users: Map<string, User>;
   private chatMessages: Map<string, ChatMessage>;
+  private chatAttachments: Map<string, ChatAttachment>;
+  private chatReactions: Map<string, ChatReaction>;
+  private chatReadReceipts: Map<string, ChatReadReceipt>;
   private tasks: Map<string, Task>;
   private knowledgeArticles: Map<string, KnowledgeArticle>;
   private meetings: Map<string, Meeting>;
@@ -53,6 +66,9 @@ export class MemStorage implements IStorage {
   constructor() {
     this.users = new Map();
     this.chatMessages = new Map();
+    this.chatAttachments = new Map();
+    this.chatReactions = new Map();
+    this.chatReadReceipts = new Map();
     this.tasks = new Map();
     this.knowledgeArticles = new Map();
     this.meetings = new Map();
@@ -87,12 +103,18 @@ export class MemStorage implements IStorage {
   }
 
   // Chat Messages
-  async getChatMessages(channelId?: string): Promise<ChatMessage[]> {
-    const messages = Array.from(this.chatMessages.values());
-    if (channelId) {
-      return messages.filter(msg => msg.channelId === channelId);
-    }
-    return messages.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+  async getChatMessages(workspaceId: string, channelId?: string): Promise<ChatMessage[]> {
+    const messages = Array.from(this.chatMessages.values()).filter(
+      (msg) => msg.workspaceId === workspaceId,
+    );
+
+    const filtered = channelId
+      ? messages.filter((msg) => msg.channelId === channelId)
+      : messages;
+
+    return filtered.sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
   }
 
   async createChatMessage(insertMessage: InsertChatMessage): Promise<ChatMessage> {
@@ -107,6 +129,95 @@ export class MemStorage implements IStorage {
     };
     this.chatMessages.set(id, message);
     return message;
+  }
+
+  async createChatAttachment(insertAttachment: InsertChatAttachment): Promise<ChatAttachment> {
+    const id = randomUUID();
+    const attachment: ChatAttachment = {
+      ...insertAttachment,
+      id,
+      uploadedAt: new Date(),
+    };
+    this.chatAttachments.set(id, attachment);
+    return attachment;
+  }
+
+  async getChatAttachments(messageIds: string[]): Promise<ChatAttachment[]> {
+    if (messageIds.length === 0) {
+      return [];
+    }
+    const idSet = new Set(messageIds);
+    return Array.from(this.chatAttachments.values()).filter((attachment) =>
+      idSet.has(attachment.messageId)
+    );
+  }
+
+  async addChatReaction(insertReaction: InsertChatReaction): Promise<ChatReaction> {
+    const existing = Array.from(this.chatReactions.values()).find((reaction) =>
+      reaction.messageId === insertReaction.messageId &&
+      reaction.userId === insertReaction.userId &&
+      reaction.emoji === insertReaction.emoji
+    );
+
+    if (existing) {
+      return existing;
+    }
+
+    const id = randomUUID();
+    const reaction: ChatReaction = {
+      ...insertReaction,
+      id,
+      createdAt: new Date(),
+    };
+    this.chatReactions.set(id, reaction);
+    return reaction;
+  }
+
+  async removeChatReaction(messageId: string, userId: string, emoji: string): Promise<void> {
+    const entry = Array.from(this.chatReactions.entries()).find(([, reaction]) =>
+      reaction.messageId === messageId &&
+      reaction.userId === userId &&
+      reaction.emoji === emoji
+    );
+    if (entry) {
+      this.chatReactions.delete(entry[0]);
+    }
+  }
+
+  async getChatReactions(messageIds: string[]): Promise<ChatReaction[]> {
+    if (messageIds.length === 0) {
+      return [];
+    }
+    const idSet = new Set(messageIds);
+    return Array.from(this.chatReactions.values()).filter((reaction) =>
+      idSet.has(reaction.messageId)
+    );
+  }
+
+  async getReadReceipt(workspaceId: string, userId: string, channelId: string): Promise<ChatReadReceipt | undefined> {
+    return this.chatReadReceipts.get(`${workspaceId}:${userId}:${channelId}`);
+  }
+
+  async upsertReadReceipt(receipt: InsertChatReadReceipt & { lastReadAt?: Date }): Promise<ChatReadReceipt> {
+    const key = `${receipt.workspaceId}:${receipt.userId}:${receipt.channelId}`;
+    const existing = this.chatReadReceipts.get(key);
+    const now = receipt.lastReadAt ?? new Date();
+
+    const record: ChatReadReceipt = {
+      id: existing?.id ?? randomUUID(),
+      workspaceId: receipt.workspaceId,
+      userId: receipt.userId,
+      channelId: receipt.channelId,
+      lastReadMessageId: receipt.lastReadMessageId ?? existing?.lastReadMessageId ?? null,
+      lastReadAt: now,
+    };
+
+    if (receipt.lastReadMessageId) {
+      record.lastReadMessageId = receipt.lastReadMessageId;
+    }
+
+    this.chatReadReceipts.set(key, record);
+    return record;
   }
 
   // Tasks


### PR DESCRIPTION
## Summary
- add workspace scoping to chat read receipts schema, storage, and API handlers
- ensure the chat page records read receipts with the active workspace and keeps the cache in sync after marking messages read
- relocate the reaction and read-receipt endpoints inside the Express route registration so they execute before returning the HTTP server

## Testing
- npm run build *(fails: Vite cannot resolve @supabase/supabase-js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10a8a17a4832896be0318974fe6b5